### PR TITLE
Replace SuSEFirewall2 by firewalld

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,3 @@ stamp-h*
 *.bak
 /testsuite/yast2-nfs-server.test/
 .yardoc/
-doc/
-doc/index.html

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ stamp-h*
 /testsuite/run/runtest.sh
 *.bak
 /testsuite/yast2-nfs-server.test/
+.yardoc/
+doc/
+doc/index.html

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,7 @@
+--no-private
+--markup markdown
+--protected
+--readme README.md
+--output-dir ./doc/autodocs
+--files *.md
+src/**/*.rb

--- a/package/yast2-nfs-server.changes
+++ b/package/yast2-nfs-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Feb  2 15:16:24 UTC 2018 - knut.anderssen@suse.com
+
+- Replace SuSEFirewall2 by firewalld (fate#323460)
+- 4.0.0
+
+-------------------------------------------------------------------
 Tue Jun  7 08:24:14 UTC 2016 - igonzalezsosa@suse.com
 
 - Stop generating autodocs (fate#320356)

--- a/package/yast2-nfs-server.spec
+++ b/package/yast2-nfs-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-nfs-server
-Version:        3.1.9
+Version:        4.0.0
 Release:        0
 URL:            https://github.com/yast/yast-nfs-server
 
@@ -26,13 +26,12 @@ Source0:        %{name}-%{version}.tar.bz2
 
 Group:	        System/YaST
 License:        GPL-2.0+
-# Changed implementation for checking if service is enabled 2.23.23 (affects testsuite)
-BuildRequires:	yast2 >= 2.23.23
+# SuSEFirewall2 replaced by firewalld (fate#323460)
+BuildRequires:	yast2 >= 4.0.39
 BuildRequires:	perl-XML-Writer update-desktop-files yast2-testsuite
 BuildRequires:  yast2-devtools >= 3.1.10
-# Service::Find
-# Wizard::SetDesktopTitleAndIcon
-Requires:	yast2 >= 2.21.22
+# SuSEFirewall2 replaced by firewalld (fate#323460)
+Requires:	yast2 >= 4.0.39
 Requires:	yast2-nfs-common
 Recommends:     nfs-kernel-server
 

--- a/src/include/nfs_server/ui.rb
+++ b/src/include/nfs_server/ui.rb
@@ -282,7 +282,7 @@ module Yast
       changed = false
 
       fw_cwm_widget = CWMFirewallInterfaces.CreateOpenFirewallWidget(
-        "services"        => ["mountd", "nfs", "rpc-bind"],
+        "services"        => ["nfs-kernel-server"],
         "display_details" => true
       )
 

--- a/src/include/nfs_server/ui.rb
+++ b/src/include/nfs_server/ui.rb
@@ -460,7 +460,7 @@ module Yast
       end while ret != :back && ret != :next && ret != :abort
 
       if ret == :next
-        # grab current settings, store them to SuSEFirewall::
+        # grab current settings, store them to firewalld::
         CWMFirewallInterfaces.OpenFirewallStore(fw_cwm_widget, "", event)
         NfsServer.start = start_nfs_server
         NfsServer.domain = Convert.to_string(

--- a/src/include/nfs_server/ui.rb
+++ b/src/include/nfs_server/ui.rb
@@ -281,13 +281,9 @@ module Yast
 
       changed = false
 
-      # firewall widget using CWM
-      fw_settings = {
-        "services"        => ["service:nfs-kernel-server"], # bnc#446163
-        "display_details" => true
-      }
       fw_cwm_widget = CWMFirewallInterfaces.CreateOpenFirewallWidget(
-        fw_settings
+        "services"        => ["mountd", "nfs", "rpc-bind"],
+        "display_details" => true
       )
 
       help_text =

--- a/src/modules/NfsServer.rb
+++ b/src/modules/NfsServer.rb
@@ -15,6 +15,7 @@
 # $Id$
 #
 require "yast"
+require "y2firewall/firewalld"
 
 module Yast
   class NfsServerClass < Module
@@ -25,7 +26,6 @@ module Yast
       Yast.import "Report"
       Yast.import "Service"
       Yast.import "Summary"
-      Yast.import "SuSEFirewall"
       Yast.import "Wizard"
 
       # default value of settings modified
@@ -137,7 +137,7 @@ module Yast
       end
 
       progress_orig = Progress.set(false)
-      SuSEFirewall.Read
+      firewalld.read
       Progress.set(progress_orig)
 
       @exports != nil
@@ -306,8 +306,7 @@ module Yast
       end
 
       progress_orig = Progress.set(false)
-      SuSEFirewall.WriteOnly
-      SuSEFirewall.ActivateConfiguration if !@write_only
+      @write_only ? firewalld.write_only : firewalld.write
       Progress.set(progress_orig)
 
       Progress.NextStage
@@ -379,6 +378,12 @@ module Yast
     publish :function => :Write, :type => "boolean ()"
     publish :function => :Summary, :type => "string ()"
     publish :function => :AutoPackages, :type => "map ()"
+
+  private
+
+    def firewalld
+      Y2Firewall::Firewalld.instance
+    end
   end
 
   NfsServer = NfsServerClass.new


### PR DESCRIPTION
- [Trello Card](https://trello.com/c/99OkErr6/1093-8-firewall-firewalld-is-the-new-susefirewall-cwm)
- It depends on some pending modifications in yast-yast2 and a requirement of yast-yast2 >= 4.0.39