### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ config.sub
 configure
 configure.in
 depcomp
-doc/
+doc/autodocs
 install-sh
 libtool
 ltconfig

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ config.sub
 configure
 configure.in
 depcomp
+doc/
 install-sh
 libtool
 ltconfig
@@ -29,3 +30,4 @@ stamp-h*
 /testsuite/run/runtest.sh
 *.bak
 /testsuite/yast2-nfs-server.test/
+.yardoc/

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,7 @@
+--no-private
+--markup markdown
+--protected
+--readme README.md
+--output-dir ./doc/autodocs
+--files *.md
+src/**/*.rb


### PR DESCRIPTION
Just to make [Travis](https://travis-ci.org/yast/yast-nfs-server/builds/560984258) happy again :)

```
rake aborted!
New files missing in git (or add them to to .gitignore):
.yardoc/checksums
.yardoc/object_types
.yardoc/objects/root.dat
.yardoc/proxy_types
doc/_index.html
doc/class_list.html
doc/css/common.css
doc/css/full_list.css
doc/css/style.css
doc/file.README.html
doc/file_list.html
doc/frames.html
doc/js/app.js
doc/js/full_list.js
doc/js/jquery.js
doc/method_list.html
doc/top-level-namespace.html
```