### PR TITLE
Add Yard options file

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,7 @@
+--no-private
+--markup markdown
+--protected
+--readme README.md
+--output-dir ./doc/autodocs
+--files *.md
+src/**/*.rb


### PR DESCRIPTION
Add our typical `.yardopts` file to generate to set `doc/autodocs` as our documentation directory. This file is already in the `master` branch.