### PR TITLE
Fixed outdated rpc-svcgssd service name. (bsc#972488)

### DIFF
--- a/package/yast2-nfs-server.changes
+++ b/package/yast2-nfs-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jan 15 16:28:52 UTC 2020 - Christopher Hofmann <cwh@suse.com>
+
+- Fixed outdated rpc-svcgssd service name (bsc#972488)
+- 4.1.1
+
+-------------------------------------------------------------------
 Tue Feb 26 13:00:14 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - Version bump (bsc#1124009)

--- a/package/yast2-nfs-server.spec
+++ b/package/yast2-nfs-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-nfs-server
-Version:        4.1.0
+Version:        4.1.1
 Release:        0
 URL:            https://github.com/yast/yast-nfs-server
 

--- a/src/modules/NfsServer.rb
+++ b/src/modules/NfsServer.rb
@@ -20,7 +20,8 @@ require "y2firewall/firewalld"
 module Yast
   class NfsServerClass < Module
     SERVICE = "nfs-server".freeze
-
+    GSSERVICE = "rpc-svcgssd".freeze
+    
     def main
       textdomain "nfs_server"
 
@@ -277,28 +278,28 @@ module Yast
         end
 
         if @nfs_security
-          if !Service.active?("svcgssd")
-            unless Service.Start("svcgssd")
-              # FIXME svcgssd is gone! (only nfsserver is left)
+          if !Service.active?(GSSERVICE)
+            unless Service.Start(GSSERVICE)
+              # FIXME #{GSSERVICE} is gone! (only nfsserver is left)
               Report.Error(
                 _(
-                  "Unable to start svcgssd. Ensure your kerberos and gssapi (nfs-utils) setup is correct."
+                  "Unable to start #{GSSERVICE}. Ensure your kerberos and gssapi (nfs-utils) setup is correct."
                 )
               )
               ok = false
             end
           else
-            unless Service.Restart("svcgssd")
+            unless Service.Restart(GSSERVICE)
               Report.Error(
-                _("Unable to restart 'svcgssd' service.")
+                _("Unable to restart '#{GSSERVICE}' service.")
               )
               ok = false
             end
           end
         else
-          if Service.active?("svcgssd")
-            unless Service.Stop("svcgssd")
-              Report.Error(_("'svcgssd' is running. Unable to stop it."))
+          if Service.active?(GSSERVICE)
+            unless Service.Stop(GSSERVICE)
+              Report.Error(_("'#{GSSERVICE}' is running. Unable to stop it."))
               ok = false
             end
           end

--- a/src/modules/NfsServer.rb
+++ b/src/modules/NfsServer.rb
@@ -283,7 +283,7 @@ module Yast
               # FIXME #{GSSERVICE} is gone! (only nfsserver is left)
               Report.Error(
                 _(
-                  "Unable to start #{GSSERVICE}. Ensure your kerberos and gssapi (nfs-utils) setup is correct."
+                  "Unable to start svcgssd. Ensure your kerberos and gssapi (nfs-utils) setup is correct."
                 )
               )
               ok = false
@@ -291,7 +291,7 @@ module Yast
           else
             unless Service.Restart(GSSERVICE)
               Report.Error(
-                _("Unable to restart '#{GSSERVICE}' service.")
+                _("Unable to restart 'svcgssd' service.")
               )
               ok = false
             end
@@ -299,7 +299,7 @@ module Yast
         else
           if Service.active?(GSSERVICE)
             unless Service.Stop(GSSERVICE)
-              Report.Error(_("'#{GSSERVICE}' is running. Unable to stop it."))
+              Report.Error(_("'svcgssd' is running. Unable to stop it."))
               ok = false
             end
           end


### PR DESCRIPTION
This is heavily based on #38. This pull request simply reverts the changes done there to translatable strings, so they can be actually processed by gettext.

The original problem was that the name of the systemd unit used to manage `svcgssd` has changed. This adapts the code to use the new name.

I haven't tested it (I just fixed the mentioned problem with translations), I trust Christopher already did all the manual testing before opening #38.

See more development info in these two Trello cards:

- https://trello.com/c/ci7mFsV9/1493-3-tw-p4-1060159-yast2-nfs-server-and-yast2-nfs-client-should-use-the-same-service-names-as-upstream-nfs-utils-edit
- https://trello.com/c/CMIez2NN/1559-sles12-sp1-p5-972488-yast2-nfs-server-failed-to-restart-nfs-service-unable-to-start-svcgssd-even-it-is-already-running
