### PR TITLE
Adapt unit test to recent changes in Yast::Report and Yast2::Popup

### DIFF
--- a/package/yast2-nfs-server.changes
+++ b/package/yast2-nfs-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb 15 07:34:12 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Adapted unit test to recent changes in Yast::Report (related to
+  bsc#1179893).
+- 4.3.2
+
+-------------------------------------------------------------------
 Mon Aug 10 17:31:10 CEST 2020 - schubi@suse.de
 
 - AutoYaST: Added supplements: autoyast(nfs-server) into the spec file

--- a/package/yast2-nfs-server.spec
+++ b/package/yast2-nfs-server.spec
@@ -18,7 +18,7 @@
 
 Name:           yast2-nfs-server
 Summary:        YaST2 - NFS Server Configuration
-Version:        4.3.1
+Version:        4.3.2
 Release:        0
 URL:            https://github.com/yast/yast-nfs-server
 Group:          System/YaST


### PR DESCRIPTION
This pull request in yast-yast2 (https://github.com/yast/yast-yast2/pull/1122) changed the behavior during unit tests of `Yast::Report` and `Yast2::Popup`, making necessary to add some extra mocking to prevent YaST from trying to open windows during the test execution.

As far as we know, that affected the test-suites of: yast-storage-ng, yast-country, yast-firewall, yast-nfs-server, yast-nis-client, yast-pam, yast-security, yast-services-manager and yast-sysconfig.

This should fix the problem for this repository.