### PR TITLE
Fix the detection of the AutoYaST client

### DIFF
--- a/package/yast2-nfs-server.changes
+++ b/package/yast2-nfs-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jul 23 10:08:49 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Set X-SuSE-YaST-AutoInstClient in the desktop file to properly
+  determine the client name (bsc#1188618).
+- 4.2.5
+
+-------------------------------------------------------------------
 Thu Jan 23 14:54:17 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Fix exit codes for CLI (bsc#1142979)

--- a/package/yast2-nfs-server.spec
+++ b/package/yast2-nfs-server.spec
@@ -18,7 +18,7 @@
 
 Name:           yast2-nfs-server
 Summary:        YaST2 - NFS Server Configuration
-Version:        4.2.4
+Version:        4.2.5
 Release:        0
 URL:            https://github.com/yast/yast-nfs-server
 Group:          System/YaST

--- a/src/desktop/org.opensuse.yast.NFSServer.desktop
+++ b/src/desktop/org.opensuse.yast.NFSServer.desktop
@@ -12,6 +12,7 @@ X-SuSE-YaST-RootOnly=true
 X-SuSE-YaST-AutoInst=all
 X-SuSE-YaST-Geometry=
 X-SuSE-YaST-SortKey=
+X-SuSE-YaST-AutoInstClient=nfs_server_auto
 X-SuSE-YaST-AutoInstClonable=true
 X-SuSE-YaST-AutoInstRequires=lan
 X-SuSE-YaST-AutoInstSchema=nfs_server.rnc


### PR DESCRIPTION
This PR fixes [bsc#1188618](https://bugzilla.suse.com/show_bug.cgi?id=1188618).

AutoYaST relies on `.desktop` files for several things, like finding out which client is expected to process each section of the profile. After the changes introduced in SP2 regarding the `.desktop` files, it is not possible to match `NFSServer.desktop` with the client. Setting the `X-SuSE-YaST-AutoInstClient` client does the trick.

Another option would be to rename the client, but I prefer to be conservative just in case anyone is relying on it outside of the YaST team.