### PR TITLE
bsc#1188618: fix AutoYaST corresponding section

### DIFF
--- a/package/yast2-nfs-server.changes
+++ b/package/yast2-nfs-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Aug 17 13:46:27 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix the corresponding section name in the package specification
+  (bsc#1188618).
+- 4.3.4
+
+-------------------------------------------------------------------
 Fri Jul 23 10:08:49 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Set X-SuSE-YaST-AutoInstClient in the desktop file to properly

--- a/package/yast2-nfs-server.spec
+++ b/package/yast2-nfs-server.spec
@@ -40,7 +40,7 @@ Requires:       yast2-ruby-bindings >= 1.0.0
 
 Recommends:     nfs-kernel-server
 
-Supplements:    autoyast(nfs-server)
+Supplements:    autoyast(nfs_server)
 
 BuildArch:      noarch
 

--- a/package/yast2-nfs-server.spec
+++ b/package/yast2-nfs-server.spec
@@ -18,7 +18,7 @@
 
 Name:           yast2-nfs-server
 Summary:        YaST2 - NFS Server Configuration
-Version:        4.3.3
+Version:        4.3.4
 Release:        0
 URL:            https://github.com/yast/yast-nfs-server
 Group:          System/YaST


### PR DESCRIPTION
Fixes [bsc#1188618](https://bugzilla.suse.com/show_bug.cgi?id=1188618). Starting in SLE 15 SP3, AutoYaST uses a new mechanism to find the needed packages (based on RPM Supplements), so #51 is not enough.